### PR TITLE
show edit button  on home recipes

### DIFF
--- a/src/Components/Recipe/Result/RecipeResult.tsx
+++ b/src/Components/Recipe/Result/RecipeResult.tsx
@@ -96,7 +96,7 @@ const RecipeResult: FC<RecipeResultProps> = ({ recipe, actionProps }) => {
             </Grid>
 
             <Grid item xs={12}>
-                {user && actionProps.actionsEnabled && (
+                {user && !actionProps.draggEnabled && (
                     <Box textAlign="right">
                         <Button
                             color="primary"


### PR DESCRIPTION
Der Bearbeiten Button wurde auf den aufklappbaren Rezepten der Home-Komponente nicht mehr angezeigt. 
Jetzt wieder