### PR TITLE
fix all source files (ts/tsx) pre build

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,4 @@
             "prettier/prettier": "warn"
         }
     },
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
-    }
 }

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,6 +1,15 @@
 const Webpack = require('webpack')
 
 module.exports = function override(config, env) {
+    config.module.rules.push({
+        enforce: 'pre',
+        test: /\.ts(x?)$/,
+        exclude: /node_modules/,
+        loader: 'eslint-loader',
+        options: {
+            fix: true,
+        },
+    })
     config.plugins.push(
         new Webpack.DefinePlugin({
             __VERSION__: JSON.stringify(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3171,6 +3171,11 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -5681,15 +5686,52 @@
       }
     },
     "eslint-loader": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.3.tgz",
-      "integrity": "sha512-+YRqB95PnNvxNp1HEjQmvf9KNvCin5HXYYseOXVC2U0KEcw4IkQ2IQEBG46j7+gW39bMzeu0GsUhVbBY3Votpw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-4.0.0.tgz",
+      "integrity": "sha512-QoaFRdh3oXt5i2uonSjO8dDnncsG05w7qvA7yYMvGDne8zAEk9R+R1rsfunp3OKVdO5mAJelf1x2Z1kYp664kA==",
       "requires": {
-        "fs-extra": "^8.1.0",
-        "loader-fs-cache": "^1.0.2",
-        "loader-utils": "^1.2.3",
-        "object-hash": "^2.0.1",
-        "schema-utils": "^2.6.1"
+        "fs-extra": "^9.0.0",
+        "loader-fs-cache": "^1.0.3",
+        "loader-utils": "^2.0.0",
+        "object-hash": "^2.0.3",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+          "integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+        }
       }
     },
     "eslint-module-utils": {
@@ -13266,6 +13308,18 @@
         "workbox-webpack-plugin": "4.3.1"
       },
       "dependencies": {
+        "eslint-loader": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.3.tgz",
+          "integrity": "sha512-+YRqB95PnNvxNp1HEjQmvf9KNvCin5HXYYseOXVC2U0KEcw4IkQ2IQEBG46j7+gW39bMzeu0GsUhVbBY3Votpw==",
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "loader-fs-cache": "^1.0.2",
+            "loader-utils": "^1.2.3",
+            "object-hash": "^2.0.1",
+            "schema-utils": "^2.6.1"
+          }
+        },
         "resolve": {
           "version": "1.15.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"clipboard-copy": "^3.1.0",
 		"clsx": "^1.1.0",
 		"eslint-config-prettier": "^6.10.1",
+		"eslint-loader": "^4.0.0",
 		"eslint-plugin-prettier": "^3.1.2",
 		"eslint-plugin-simple-import-sort": "^5.0.2",
 		"firebase": "^7.12.0",

--- a/src/Components/Recipe/Result/RecipeResult.tsx
+++ b/src/Components/Recipe/Result/RecipeResult.tsx
@@ -1,4 +1,4 @@
-import { Divider, Grid } from '@material-ui/core'
+import { Grid } from '@material-ui/core'
 import AssignmentIcon from '@material-ui/icons/Assignment'
 import BookIcon from '@material-ui/icons/Book'
 import SwapIcon from '@material-ui/icons/SwapHorizontalCircle'
@@ -35,10 +35,6 @@ const RecipeResult = ({ recipe }: RecipeResultProps) => {
             </Grid>
 
             <Attachments recipeName={recipe.name} />
-
-            <Grid item xs={12}>
-                <Divider />
-            </Grid>
 
             <Grid item xs={12}>
                 <Grid container spacing={3}>


### PR DESCRIPTION
@Miwri durch den "eslint-loader" und entsprechende Regel in config-overrides.js übernimmt nun nicht mehr vs code mit eslint Integration den Autofix. Stattdessen wird vor jedem Build eslint durch webpack getriggert.


